### PR TITLE
Fix circular imports

### DIFF
--- a/__tests__/component.test.ts
+++ b/__tests__/component.test.ts
@@ -1,5 +1,5 @@
 import { namedNode } from "@rdfjs/data-model";
-import Dimension from "../src/components/dimension";
+import {Dimension} from "../src/components";
 
 let d = null;
 

--- a/__tests__/datasetquery.test.ts
+++ b/__tests__/datasetquery.test.ts
@@ -1,7 +1,5 @@
 import { literal, namedNode } from "@rdfjs/data-model";
-import Attribute from "../src/components/attribute";
-import Dimension from "../src/components/dimension";
-import Measure from "../src/components/measure";
+import {Attribute, Dimension, Measure} from "../src/components";
 import DataCube from "../src/datacube";
 import DataSet from "../src/dataset";
 import fetch from "./utils/fetch-mock";

--- a/__tests__/filter.test.ts
+++ b/__tests__/filter.test.ts
@@ -1,6 +1,6 @@
 // tslint:disable: trailing-comma
 import { literal, namedNode } from "@rdfjs/data-model";
-import Dimension from "../src/components/dimension";
+import {Dimension} from "../src/components";
 import DataSet from "../src/dataset";
 import fetch from "./utils/fetch-mock";
 

--- a/__tests__/serialization.test.ts
+++ b/__tests__/serialization.test.ts
@@ -1,7 +1,4 @@
-import Component from "../src/components";
-import Attribute from "../src/components/attribute";
-import Dimension from "../src/components/dimension";
-import Measure from "../src/components/measure";
+import {Component, Attribute, Dimension, Measure} from "../src/components";
 import DataCube from "../src/datacube";
 import DataSet from "../src/dataset";
 import fetch from "./utils/fetch-mock";

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import { literal } from "@rdfjs/data-model";
 import namespace from "@rdfjs/namespace";
-import { toLiteral } from "../src/expressions/utils";
+import { toLiteral } from "../src/expressions";
 
 const xsd = namespace("http://www.w3.org/2001/XMLSchema#");
 const rdf = namespace("http://www.w3.org/1999/02/22-rdf-syntax-ns#");

--- a/src/components/attribute.ts
+++ b/src/components/attribute.ts
@@ -1,4 +1,4 @@
-import Component from "./component";
+import {Component} from "./index";
 
 class Attribute extends Component {
   public componentType = "attribute";

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -2,9 +2,8 @@ import { namedNode } from "@rdfjs/data-model";
 import clone from "clone";
 import { Term } from "rdf-js";
 import { Label } from "../dataset";
-import BaseExpr from "../expressions/base";
-import Binding from "../expressions/binding";
-import { IExpr } from "../expressions/utils";
+import { BaseExpr, Binding, IExpr } from "../expressions";
+import { Measure, Dimension, Attribute } from "./index";
 
 export type SerializedComponent = {
   componentType: string,
@@ -94,7 +93,3 @@ class Component extends BaseExpr {
 }
 
 export default Component;
-
-import Attribute from "./attribute";
-import Dimension from "./dimension";
-import Measure from "./measure";

--- a/src/components/dimension.ts
+++ b/src/components/dimension.ts
@@ -1,4 +1,4 @@
-import Component from "./component";
+import {Component} from "./index";
 
 class Dimension extends Component {
   public componentType = "dimension";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,11 +1,4 @@
-import Attribute from "./attribute";
-import Component from "./component";
-import Dimension from "./dimension";
-import Measure from "./measure";
-
-export default Component;
-export {
-  Dimension,
-  Attribute,
-  Measure,
-};
+export {default as Component} from "./component";
+export {default as Attribute} from "./attribute";
+export {default as Dimension} from "./dimension";
+export {default as Measure} from "./measure";

--- a/src/components/measure.ts
+++ b/src/components/measure.ts
@@ -1,4 +1,4 @@
-import Component from "./component";
+import {Component} from "./index";
 
 class Measure extends Component {
   public componentType = "measure";

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -1,7 +1,7 @@
 import { namedNode, variable } from "@rdfjs/data-model";
 import { NamedNode, Term } from "rdf-js";
 import { Generator as SparqlGenerator } from "sparqljs";
-import Component, {Attribute, Dimension, Measure} from "./components";
+import {Component, Attribute, Dimension, Measure} from "./components";
 import { ICubeOptions } from "./datacube";
 import DataSetQuery from "./query/datasetquery";
 import { generateLangCoalesce, generateLangOptionals, IQueryOptions, prefixes } from "./query/utils";

--- a/src/expressions/base.ts
+++ b/src/expressions/base.ts
@@ -1,4 +1,5 @@
 import { Literal } from "rdf-js";
+import { Operator, IExpr, IntoExpr } from "./index";
 
 const notableOperators = {
   "in": "notin",
@@ -132,7 +133,3 @@ export default class BaseExpr implements IExpr {
     return notable("!=", this, [arg]);
   }
 }
-
-// for cyclic dependencies
-import Operator from "./operator";
-import { IExpr, IntoExpr } from "./utils";

--- a/src/expressions/binding.ts
+++ b/src/expressions/binding.ts
@@ -1,5 +1,4 @@
-import BaseExpr from "./base";
-import { IExpr } from "./utils";
+import { BaseExpr, IExpr } from "./index";
 
 class Binding extends BaseExpr implements IExpr {
   public name: string;

--- a/src/expressions/index.ts
+++ b/src/expressions/index.ts
@@ -1,0 +1,10 @@
+
+export interface IExpr {
+  resolve(mapping: Map<string, string>): IExpr;
+}
+
+export { default as BaseExpr } from "./base";
+export * from "./utils";
+export { default as Operator } from "./operator";
+export { default as Binding } from "./binding";
+

--- a/src/expressions/numeric.ts
+++ b/src/expressions/numeric.ts
@@ -1,5 +1,4 @@
-import BaseExpr from "./base";
-import { IExpr } from "./utils";
+import { BaseExpr, IExpr } from "./index";
 
 class Numeric extends BaseExpr implements IExpr {
   private val: number;

--- a/src/expressions/operator.ts
+++ b/src/expressions/operator.ts
@@ -1,5 +1,4 @@
-import BaseExpr from "./base";
-import { IExpr, into, IntoExpr } from "./utils";
+import { BaseExpr, IExpr ,into, IntoExpr} from "./index";
 
 class Operator extends BaseExpr implements IExpr {
   public operator: string;

--- a/src/expressions/utils.ts
+++ b/src/expressions/utils.ts
@@ -2,8 +2,7 @@
 import { blankNode, defaultGraph, literal, namedNode, variable } from "@rdfjs/data-model";
 import namespace from "@rdfjs/namespace";
 import { Literal, Term } from "rdf-js";
-import Binding from "./binding";
-import Operator from "./operator";
+import { IExpr, Operator, Binding } from "./index"
 
 const xsd = namespace("http://www.w3.org/2001/XMLSchema#");
 
@@ -11,9 +10,7 @@ const dateTime = /^\d{4}(-[01]\d(-[0-3]\d(T[0-2]\d:[0-5]\d:?([0-5]\d(\.\d+)?)?([
 const bool = /^(true|false)$/;
 const numb = /^[\-+]?(?:\d+\.?\d*([eE](?:[\-\+])?\d+)|\d*\.?\d+)$/;
 
-export interface IExpr {
-  resolve(mapping: Map<string, string>): IExpr;
-}
+
 export type IntoExpr = Term | number | IExpr;
 
 export class TermExpr implements IExpr {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import Measure from "./components/measure";
 import BaseExpr from "./expressions/base";
 import Binding from "./expressions/binding";
 import Operator from "./expressions/operator";
-import { ArrayExpr, IExpr, into, IntoExpr, isLiteral, isTerm, TermExpr, toLiteral } from "./expressions/utils";
+import { ArrayExpr, IExpr, into, IntoExpr, isLiteral, isTerm, TermExpr, toLiteral } from "./expressions";
 
 import DataSetQuery from "./query/datasetquery";
 import { baseState, IQueryOptions, IState, PredicateFunction, Selects } from "./query/utils";

--- a/src/query/datasetquery.ts
+++ b/src/query/datasetquery.ts
@@ -1,9 +1,9 @@
 import { namedNode, variable } from "@rdfjs/data-model";
 import clone from "clone";
 import { Generator as SparqlGenerator } from "sparqljs";
-import Component from "../components/index";
+import {Component} from "../components/index";
 import DataSet from "../dataset";
-import { IExpr } from "../expressions/utils";
+import { IExpr } from "../expressions";
 import SparqlFetcher from "../sparqlfetcher";
 import { BgpPattern, FilterPattern, Ordering, SelectQuery } from "../sparqljs";
 import { baseState, combineFilters, createOperationExpression, prefixes } from "./utils";

--- a/src/query/utils.ts
+++ b/src/query/utils.ts
@@ -1,10 +1,10 @@
 import { literal, namedNode, variable } from "@rdfjs/data-model";
 import { Variable } from "rdf-js";
-import Component from "../components";
+import {Component} from "../components";
 import { ICubeOptions } from "../datacube";
 import Binding from "../expressions/binding";
 import Operator from "../expressions/operator";
-import { ArrayExpr, IExpr, into, isTerm, TermExpr } from "../expressions/utils";
+import { ArrayExpr, IExpr, into, isTerm, TermExpr } from "../expressions";
 import { BindPattern, BlockPattern, Expression, FilterPattern, OperationExpression, Tuple } from "../sparqljs";
 
 export type PredicateFunction = (data: Selects) => Component;


### PR DESCRIPTION
Fixes #14

Used the strategy outlined at https://medium.com/visual-development/how-to-fix-nasty-circular-dependency-issues-once-and-for-all-in-javascript-typescript-a04c987cf0de

I.e. only importing from a single file per "module" (in this case `expressions/index.ts`)

Sidenote: Husky failed (couldn't find config) and Prettier seemed to produce different results on my machine than yours, so everything looks a bit ugly.