### PR TITLE
Inherit Sparql Fetcher from EntryPoint

### DIFF
--- a/src/datacube.ts
+++ b/src/datacube.ts
@@ -98,7 +98,7 @@ export class DataCube {
   public graphIri?: string;
   public extraMetadata: Map<string, Literal>;
   private languages: string[];
-  private fetcher: SparqlFetcher;
+  public fetcher: SparqlFetcher;
   private componentsLoaded: boolean = false;
   private cachedComponents: ComponentsCache;
 
@@ -114,9 +114,10 @@ export class DataCube {
   constructor(
     endpoint: string,
     options: DataCubeOptions,
+    fetcher?: SparqlFetcher
   ) {
     const { iri, label, graphIri, extraMetadata } = options;
-    this.fetcher = new SparqlFetcher(endpoint);
+    this.fetcher = fetcher || new SparqlFetcher(endpoint, options.fetcher);
     this.endpoint = endpoint;
     this.iri = iri.value;
     this.graphIri = graphIri.value;

--- a/src/entrypoint.ts
+++ b/src/entrypoint.ts
@@ -228,7 +228,7 @@ export class DataCubeEntryPoint {
 
     Object.entries(dataCubesByIri)
       .forEach(([iri, dataCube]: [string, DataCubeOptions]) => {
-        this.cachedDataCubes.set(iri, new DataCube(this.endpoint, dataCube));
+        this.cachedDataCubes.set(iri, new DataCube(this.endpoint, dataCube, this.fetcher));
       });
   }
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -109,7 +109,7 @@ export class Query {
     this.languages = options.languages || [];
     this.dataCube = dataCube;
     this.state = baseState;
-    this.fetcher = new SparqlFetcher(this.dataCube.endpoint);
+    this.fetcher = dataCube.fetcher;
   }
 
   /**

--- a/src/sparqlfetcher.ts
+++ b/src/sparqlfetcher.ts
@@ -1,5 +1,4 @@
 import { blankNode, literal, namedNode } from "@rdfjs/data-model";
-import clone from "clone";
 import fetch, { BodyInit, RequestInit, Response } from "node-fetch";
 import { Term } from "rdf-js";
 
@@ -74,11 +73,7 @@ export class SparqlFetcher {
   }
 
   private options(body: BodyInit = ""): RequestInit {
-    const options = clone(this.fetchOptions);
-    if (body) {
-      options.body = body;
-    }
-    return options;
+    return { ...this.options, body };
   }
 }
 

--- a/src/sparqlfetcher.ts
+++ b/src/sparqlfetcher.ts
@@ -73,7 +73,11 @@ export class SparqlFetcher {
   }
 
   private options(body: BodyInit = ""): RequestInit {
-    return { ...this.options, body };
+    const options: RequestInit = { ...this.fetchOptions };
+    if (body) {
+      options.body = body;
+    }
+    return options;
   }
 }
 


### PR DESCRIPTION
DataCube and Query should inherit the SparqlFetcher from the EntryPoint, since this is the only place to specify the fetcher options. I don't think there's a benefit to creating one fetcher per cube/query instance, so they just reuse the same one.

I also removed the bit that clones the options on each request, since I don't think it's necessary and may even be bad when a custom HTTP agent is used (which is necessary to make this work [with a proxy](https://github.com/TooTallNate/node-https-proxy-agent/) – which is why I discovered this bug in the first place).

I wrote it in a way that changes the minimal amount of code but haven't fixed the `fromJSON` methods (fetcherOptions were not serialized anyway).